### PR TITLE
Separate cache_image from pipeline

### DIFF
--- a/nextshot.sh
+++ b/nextshot.sh
@@ -6,14 +6,16 @@ _CONFIG_FILE="$_CONFIG_DIR/nextshot.conf"
 set -Eeo pipefail
 
 nextshot() {
-    local filename json url
+    local image filename json url
 
     sanity_check
     parse_opts "$@"
     load_config
     init_cache
 
-    filename=$(cache_image | nc_upload)
+    image=$(cache_image)
+    filename="$(echo "$image" | nc_upload)"
+
     json=$(nc_share "$filename")
     url="$(echo "$json" | make_url)"
 


### PR DESCRIPTION
Fixes #6 (finally!)

This function actually returns filename just the same as nc_upload does,
so this could really be improved (probably just by having a single
global filename variable that everything uses), but removing it from the
pipeline is good enough for now... even if it is a bit duplicative.