### PR TITLE
Config cleanup

### DIFF
--- a/nextshot.sh
+++ b/nextshot.sh
@@ -359,6 +359,16 @@ rename=false
 EOF
 }
 
+config_complete() {
+    echo
+    echo "Config saved! It can be found in $_CONFIG_FILE"
+    echo "If you wish to make further changes, open it in your favourite text editor."
+    echo
+    echo "You may now run nextshot again to start taking screenshots."
+
+    exit 0
+}
+
 if [ ! -d "$_CONFIG_DIR" ]; then
     if ! has yad; then
         echo "Failed to detect Yad, required to display the initial configuration window."
@@ -378,12 +388,8 @@ if [ ! -d "$_CONFIG_DIR" ]; then
 
         echo "Opening config for editing"
         ${EDITOR:-vi} "$_CONFIG_FILE"
-        echo
-        echo "Config saved! If you wish to make further changes, open $_CONFIG_FILE in your favourite editor."
-        echo
-        echo "You may now run nextshot again to start taking screenshots."
 
-        exit 0
+        config_complete
     fi
 
     response=$(yad --title "NextShot Configuration" --text="<b>Welcome to NextShot\!</b>
@@ -414,8 +420,7 @@ and click <b>Create new app password</b>.\n:LBL" \
 
     mkdir -p "$_CONFIG_DIR" && sed 's/\\n/\n/g' <<< "$config" > "$_CONFIG_FILE"
 
-    echo "Config saved to $_CONFIG_FILE"
-    exit 0
+    config_complete
 fi
 
 nextshot "$@"

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -407,13 +407,12 @@ and click <b>Create new app password</b>.\n:LBL" \
     IFS='|' read -r server _ username password _ rename savedir _ <<< "$response"
     rename=${rename//\'/}
 
-    mkdir -p "$_CONFIG_DIR"
-
-    tmpConfig="server=$server\nusername=$username\npassword=$password\nsavedir=$savedir\nrename=$rename"
-
-    yad --title="NextShot Configuration" --borders=10 --button="gtk-save" --separator='' \
+    config=$(yad --title="NextShot Configuration" --borders=10 --button="gtk-save" --separator='' \
         --text="Check the config below and correct any errors before saving:" --fixed\
-        --width=400 --height=175 --form --field=":TXT" "$tmpConfig" | sed 's/\\n/\n/g' > "$_CONFIG_FILE"
+        --width=400 --height=175 --form --field=":TXT" \
+        "server=$server\nusername=$username\npassword=$password\nsavedir=$savedir\nrename=$rename") || abort_config
+
+    mkdir -p "$_CONFIG_DIR" && sed 's/\\n/\n/g' <<< "$config" > "$_CONFIG_FILE"
 
     echo "Config saved to $_CONFIG_FILE"
     exit 0

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -22,6 +22,11 @@ nextshot() {
     echo "$url" | to_clipboard && send_notification
 }
 
+abort_config() {
+    echo "Configuration aborted by user, exiting." >&2
+    exit 1
+}
+
 aborted() {
     echo -e "\nAborted by user"
     exit 1
@@ -396,12 +401,7 @@ and click <b>Create new app password</b>.\n:LBL" \
         --field="Prompt to rename screenshots before upload:CHK" \
         --field="Screenshot Folder" \
         --field="This is where screenshots will be uploaded on Nextcloud, relative to your user root.\n:LBL" \
-        "https://" "" "" "" "" true "Screenshots")
-
-    if $response; then
-        echo "Configuration aborted by user, exiting."
-        exit
-    fi
+        "https://" "" "" "" "" true "Screenshots") || abort_config
 
     IFS='|' read -r server _ username password _ rename savedir _ <<< "$response"
     rename=${rename//\'/}

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -413,9 +413,9 @@ and click <b>Create new app password</b>.\n:LBL" \
     IFS='|' read -r server _ username password _ rename savedir _ <<< "$response"
     rename=${rename//\'/}
 
-    config=$(yad --title="NextShot Configuration" --borders=10 --button="gtk-save" --separator='' \
+    config=$(yad --title="NextShot Configuration" --borders=10 --separator='' \
         --text="Check the config below and correct any errors before saving:" --fixed\
-        --width=400 --height=175 --form --field=":TXT" \
+        --button="gtk-cancel:1" --button="gtk-save:0" --width=400 --height=175 --form --field=":TXT" \
         "server=$server\nusername=$username\npassword=$password\nsavedir=$savedir\nrename=$rename") || abort_config
 
     mkdir -p "$_CONFIG_DIR" && sed 's/\\n/\n/g' <<< "$config" > "$_CONFIG_FILE"

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -23,6 +23,10 @@ nextshot() {
 }
 
 abort_config() {
+    if ! has yad; then
+        echo "Either install Yad, or configure NextShot manually."
+    fi
+
     echo "Configuration aborted by user, exiting." >&2
     exit 1
 }
@@ -362,27 +366,24 @@ if [ ! -d "$_CONFIG_DIR" ]; then
         echo
 
         read -rn1 -p "Create config for manual editing (y/n)? " answer
+        echo
 
-        if [ "${answer,,}" = "y" ]; then
-            echo
-            echo -n "Creating nextshot directory... "
-            mkdir -p "$_CONFIG_DIR" && echo "[DONE]"
+        [ "${answer,,}" = "y" ] || abort_config
 
-            echo -n "Creating config template... "
-            create_config && echo "[DONE]"
+        echo -n "Creating nextshot directory... "
+        mkdir -p "$_CONFIG_DIR" && echo "[DONE]"
 
-            echo "Opening config for editing"
-            ${EDITOR:-vi} "$_CONFIG_FILE"
-            echo
-            echo "Config saved! If you wish to make further changes, open $_CONFIG_FILE in your favourite editor."
-            echo
-            echo "You may now run nextshot again to start taking screenshots."
+        echo -n "Creating config template... "
+        create_config && echo "[DONE]"
 
-            exit 0
-        fi
+        echo "Opening config for editing"
+        ${EDITOR:-vi} "$_CONFIG_FILE"
+        echo
+        echo "Config saved! If you wish to make further changes, open $_CONFIG_FILE in your favourite editor."
+        echo
+        echo "You may now run nextshot again to start taking screenshots."
 
-        echo "Aborting. Either install Yad, or configure NextShot manually."
-        exit 1
+        exit 0
     fi
 
     response=$(yad --title "NextShot Configuration" --text="<b>Welcome to NextShot\!</b>


### PR DESCRIPTION
Reworks a bunch of the config code to fix #27 among other issues where aborting config would be caught by the `ERR` trap introduced in #31 rather than failing "gracefully" with the config aborted message.