### PR TITLE
Add validation of config options

### DIFF
--- a/nextshot.sh
+++ b/nextshot.sh
@@ -179,9 +179,9 @@ load_config() {
     # shellcheck disable=SC1090
     echo "Loading config from $_CONFIG_FILE..." && . "$_CONFIG_FILE" && echo "Ready!"
 
-    : "${server:?"Required config option missing. Please set 'server' to your Nextcloud Base URL."}"
-    : "${username:?"Required config option missing. Please set 'username' to your Nextcloud username."}"
-    : "${password:?"Required config option missing. Please set 'password' to your Nextcloud App Password."}"
+    local errmsg="missing required config option."
+    : "${server:?$errmsg}" "${username:?$errmsg}" "${password:?$errmsg}"
+
     rename=${rename:-false}
     rename=${rename,,}
 

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -180,7 +180,7 @@ load_config() {
     echo "Loading config from $_CONFIG_FILE..." && . "$_CONFIG_FILE"
 
     local errmsg="missing required config option."
-    : "${server:?$errmsg}" "${username:?$errmsg}" "${password:?$errmsg}"
+    : "${server:?$errmsg}" "${username:?$errmsg}" "${password:?$errmsg}" "${savedir:?$errmsg}"
 
     rename=${rename:-false}
     rename=${rename,,}

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -177,7 +177,7 @@ init_cache() {
 
 load_config() {
     # shellcheck disable=SC1090
-    echo "Loading config from $_CONFIG_FILE..." && . "$_CONFIG_FILE" && echo "Ready!"
+    echo "Loading config from $_CONFIG_FILE..." && . "$_CONFIG_FILE"
 
     local errmsg="missing required config option."
     : "${server:?$errmsg}" "${username:?$errmsg}" "${password:?$errmsg}"
@@ -185,7 +185,7 @@ load_config() {
     rename=${rename:-false}
     rename=${rename,,}
 
-    parse_colour
+    parse_colour && echo "Config loaded!"
 }
 
 parse_colour() {

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -179,6 +179,9 @@ load_config() {
     # shellcheck disable=SC1090
     echo "Loading config from $_CONFIG_FILE..." && . "$_CONFIG_FILE" && echo "Ready!"
 
+    : "${server:?"Required config option missing. Please set 'server' to your Nextcloud Base URL."}"
+    : "${username:?"Required config option missing. Please set 'username' to your Nextcloud username."}"
+    : "${password:?"Required config option missing. Please set 'password' to your Nextcloud App Password."}"
     rename=${rename:-false}
     rename=${rename,,}
 


### PR DESCRIPTION
Resolves #25. If any required options are missing (or `null`) in `nextshot.conf`, Nextshot will now abort with an error message.