### PR TITLE
Let `file` check existence of images

### DIFF
--- a/nextshot.sh
+++ b/nextshot.sh
@@ -268,7 +268,10 @@ parse_colour() {
 
 cache_image() {
     if [ "$mode" = "file" ]; then
-        cp "$PWD/$file" "$_CACHE_DIR/$file" && echo "$file"
+        local filename
+        filename="$(basename "$file")"
+
+        cp "$file" "$_CACHE_DIR/$filename" && echo "$filename"
     else
         take_screenshot
     fi

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -164,12 +164,9 @@ parse_opts() {
                 file="$2"
                 mode="file"
 
-                if [ ! -f "$PWD/$file" ]; then
-                    echo "File $file could not be found!"
-                    exit 1
-                fi
+                # If file cannot be found here, $mimetype will be the error from `file`
+                mimetype="$(file -E --mime-type -b "$file")" || (echo "$mimetype" && exit 1)
 
-                mimetype="$(file --mime-type -b "$file")"
                 if [ ! "${mimetype:0:6}" = "image/" ]; then
                     echo "Failed MIME check: expected image/*, got '$mimetype'."
                     exit 1


### PR DESCRIPTION
Checking for "$PWD/$file" causes root-relative paths to file. The file
command's -E option will force it to issue an error message and exit,
which is arguably a much better way of doing things.

Also updates `cache_name` function to use basename instead of full path.

Fixes #22.