### PR TITLE
Add Wayland window selection GUI (take 2)

### DIFF
--- a/nextshot.sh
+++ b/nextshot.sh
@@ -443,7 +443,7 @@ select_window() {
         titles+=("$title")
 
         if has yad; then
-            yadlist+=($num "$title" "$size")
+            yadlist+=("$num" "$title" "$size")
         else
             echo "[$num] $title" >&2
         fi
@@ -452,6 +452,7 @@ select_window() {
 
     if has yad; then
         choice=$(select_window_gui)
+        choice=${choice//|}
     else
         select_window_cli
     fi

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -210,6 +210,11 @@ has() {
     type "$1" >/dev/null 2>&1 || return 1
 }
 
+# shellcheck disable=SC2009
+is_interactive() {
+    ps -o stat= -p $$ | grep -q '+'
+}
+
 is_wayland() {
     [ -n "${WAYLAND_DISPLAY+x}" ]
 }
@@ -442,19 +447,19 @@ select_window() {
         geometries+=("$offset $size")
         titles+=("$title")
 
-        if has yad; then
-            yadlist+=("$num" "$title" "$size")
-        else
+        if is_interactive; then
             echo "[$num] $title" >&2
+        else
+            yadlist+=("$num" "$title" "$size")
         fi
         ((num+=1))
     done <<< "$windows"
 
-    if has yad; then
+    if is_interactive; then
+        select_window_cli
+    else
         choice=$(select_window_gui)
         choice=${choice//|}
-    else
-        select_window_cli
     fi
 
     echo "Selected window $choice: ${titles[$choice]}" >&2

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -457,9 +457,12 @@ select_window() {
 
     if is_interactive; then
         select_window_cli
-    else
+    elif has yad; then
         choice=$(select_window_gui)
         choice=${choice//|}
+    else
+        echo "Unable to display window selection. Install Yad or run 'nextshot -w' in a terminal." >&2
+        exit 1
     fi
 
     echo "Selected window $choice: ${titles[$choice]}" >&2

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -458,8 +458,7 @@ select_window() {
     if is_interactive; then
         select_window_cli
     elif has yad; then
-        choice=$(select_window_gui)
-        choice=${choice//|}
+        select_window_gui
     else
         echo "Unable to display window selection. Install Yad or run 'nextshot -w' in a terminal." >&2
         exit 1
@@ -484,8 +483,10 @@ select_window_cli() {
 }
 
 select_window_gui() {
-    yad --list --print-column=1 --hide-column=1 --column="#:NUM" \
-        --column="Window Title" --column="Dimensions" "${yadlist[@]}"
+    choice=$(yad --list --print-column=1 --hide-column=1 --column="#:NUM" \
+        --column="Window Title" --column="Dimensions" "${yadlist[@]}") || \
+        (echo "Window selection cancelled by user." >&2; exit 1)
+    choice=${choice//|}
 }
 
 send_notification() {

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -443,7 +443,7 @@ select_window() {
         titles+=("$title")
 
         if has yad; then
-            yadlist+=("$title" "$size")
+            yadlist+=($num "$title" "$size")
         else
             echo "[$num] $title" >&2
         fi
@@ -451,7 +451,7 @@ select_window() {
     done <<< "$windows"
 
     if has yad; then
-        select_window_gui
+        choice=$(select_window_gui)
     else
         select_window_cli
     fi
@@ -475,7 +475,8 @@ select_window_cli() {
 }
 
 select_window_gui() {
-    yad --list --column="Window Title" --column="Dimensions" "${yadlist[@]}"
+    yad --list --print-column=1 --hide-column=1 --column="#:NUM" \
+        --column="Window Title" --column="Dimensions" "${yadlist[@]}"
 }
 
 send_notification() {

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -484,6 +484,7 @@ select_window_cli() {
 
 select_window_gui() {
     choice=$(yad --list --print-column=1 --hide-column=1 --column="#:NUM" \
+        --width=550 --height=400 --title"NextShot: Select window to capture" \
         --column="Window Title" --column="Dimensions" "${yadlist[@]}") || \
         (echo "Window selection cancelled by user." >&2; exit 1)
     choice=${choice//|}


### PR DESCRIPTION
Adds a new list dialog using Yad to fix #42.

### todo
- [x] Create dialog populated with list of windows
- [x] Enable selection of window and return choice
- [x] Show dialog only when called from keybinding

Second attempt. When I forgot to push a single "new" commit on develop before this branch, Github messed up the commit list on #44 and no amount of close/reopen/delete/push/force would fix it. Note to self: make sure you pushed develop before you push a new branch that bases off an unpushed commit :man_facepalming: