### PR TITLE
Capture delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ bypass Nextcloud and instead copy the image to clipboard, add the `-c` or `--cli
 
     `nextshot -f` or `nextshot --fullscreen`
 
+Image capture can also be delayed by passing the `-d`, `--delay` option followed by a `TIMEOUT`, for
+example `nextshot -d3.5` or `nextshot --delay 2m` to delay 3.5 seconds or 2 minutes respectively.
+
 To abort selection in the `--area` or `--window` modes, press the Escape key.
 
 ### Upload Modes

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -205,7 +205,7 @@ parse_opts() {
             -w|--window)
                 mode="window"; shift ;;
             -d|--delay)
-                delay=${2//=}; shift ;;
+                delay=${2//=}; shift 2 ;;
             --file)
                 local mimetype
 
@@ -242,7 +242,7 @@ parse_opts() {
 }
 
 delay_capture() {
-    [ "$delay" -gt 0 ] && sleep "$delay"
+    [ "$delay" -gt 0 ] && echo "Waiting for ${delay} seconds..." >&2 && sleep "$delay"
 }
 
 has() {

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -411,16 +411,15 @@ take_screenshot() {
 }
 
 shoot_wayland() {
-    if [ "$mode" = "selection" ]; then
-        grim -g "$(slurp -d -c "${hlColour}ee" -s "${hlColour}66")" "$1"
-    elif [ "$mode" = "window" ]; then
-        local geometry
+    local args
 
-        geometry="$(select_window)"
-        grim -g "$geometry" "$1"
-    else
-        grim "$1"
+    if [ "$mode" = "selection" ]; then
+        args=(-g "$(slurp -d -c "${hlColour}ee" -s "${hlColour}66")")
+    elif [ "$mode" = "window" ]; then
+        args=(-g "$(select_window)")
     fi
+
+    grim "${args[@]}" "$1"
 }
 
 shoot_x() {

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -240,6 +240,10 @@ parse_opts() {
     echo "Output will be sent to ${output_mode^}"
 }
 
+delay_capture() {
+    [ "$delay" -gt 0 ] && sleep "$delay"
+}
+
 has() {
     type "$1" >/dev/null 2>&1 || return 1
 }
@@ -419,6 +423,7 @@ shoot_wayland() {
         args=(-g "$(select_window)")
     fi
 
+    delay_capture
     grim "${args[@]}" "$1"
 }
 
@@ -435,8 +440,7 @@ shoot_x() {
         args=(-window "$($slop -f "%i" -t 999999)")
     fi
 
-    [ "$delay" -gt 0 ] && sleep "$delay"
-
+    delay_capture
     import "${args[@]}" "$1"
 }
 

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -157,8 +157,8 @@ setup() {
 }
 
 parse_opts() {
-    local -r OPTS=D::htVawfpc
-    local -r LONG=deps::,dependencies::,help,tray,version,area,window,fullscreen,paste,file:,clipboard
+    local -r OPTS=D::htVawd:fpc
+    local -r LONG=deps::,dependencies::,help,tray,version,area,window,delay:,fullscreen,paste,file:,clipboard
     local parsed
 
     ! parsed=$(getopt -o "$OPTS" -l "$LONG" -n "$0" -- "${@:---area}")
@@ -203,6 +203,8 @@ parse_opts() {
                 mode="fullscreen"; shift ;;
             -w|--window)
                 mode="window"; shift ;;
+            -d|--delay)
+                delay=${2//=}; shift ;;
             --file)
                 local mimetype
 
@@ -433,6 +435,8 @@ shoot_x() {
     elif [ "$mode" = "window" ]; then
         args=(-window "$($slop -f "%i" -t 999999)")
     fi
+
+    [ "$delay" -gt 0 ] && sleep "$delay"
 
     import "${args[@]}" "$1"
 }

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -162,7 +162,7 @@ parse_opts() {
     local -r LONG=deps::,dependencies::,help,tray,version,area,window,delay:,fullscreen,paste,file:,clipboard
     local parsed
 
-    ! parsed=$(getopt -o "$OPTS" -l "$LONG" -n "$0" -- "${@:---area}")
+    ! parsed=$(getopt -o "$OPTS" -l "$LONG" -n "$0" -- "$@")
     if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
         echo "Run 'nextshot --help' for a list of commands."
         exit 2
@@ -237,6 +237,7 @@ parse_opts() {
         esac
     done
 
+    : ${mode:=selection}
     echo "Screenshot mode set to $mode"
     echo "Output will be sent to ${output_mode^}"
 }

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -47,6 +47,7 @@ usage() {
     echo "  -a, --area        Capture only the selected area"
     echo "  -f, --fullscreen  Capture the entire X/Wayland display"
     echo "  -w, --window      Capture a single window"
+    echo "  -d, --delay=NUM   Pause for NUM seconds before capture"
     echo
     echo "Upload Modes:"
     echo


### PR DESCRIPTION
Adds a `-d` option (aliased as `--delay`) which requires a single argument `NUMBER` to specify a delay in seconds (by default).

Minutes, hours and days can be specified (if you're insane) by using the `m`, `h` or `d` suffix to `NUMBER`, e.g. `-d5m`.

Closes #18.