### PR TITLE
Add ability to rename without Yad in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Added
+* CLI prompt for renaming screenshots when running interactively
 
 
 ## [1.1.1] - 2019-04-04

--- a/README.md
+++ b/README.md
@@ -229,8 +229,9 @@ Defaults to `false`
 
 #### `rename` - optional
 
-When you have Yad and set this option to `true`, this option will prompt you to enter a custom filename
-before uploading to Nextcloud. Be sure to include the extension as it will not be added automatically.
+When you set this option to `true`, Nextshot will prompt you to enter a custom filename before
+uploading to Nextcloud. Be sure to include the extension as it will not be added automatically.
+Triggering Nextshot from the [#tray-menu](tray menu) or a [#recommended-shortcuts](keybinding) will require Yad for the rename prompt.
 
 Defaults to `false`.
 

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -453,17 +453,19 @@ shoot_x() {
 attempt_rename() {
     local newname
 
-    if [ ! "$rename" = true ] || ! has yad; then echo "$1"
-    else
-        newname=$(yad --entry --title "NextShot" --borders=10 --button="gtk-save" --entry-text="$1" \
-            --text="<b>Screenshot Saved!</b>\nEnter filename to save to NextCloud:" 2>/dev/null)
+    if [ "$rename" = true ] && has yad; then newname="$(rename_gui "$1")"
+    else newname="$1"; fi
 
-        if [ ! "$1" = "$newname" ]; then
-            mv "$_CACHE_DIR/$1" "$_CACHE_DIR/$newname"
-        fi
-
-        echo "$newname"
+    if [ ! "$1" = "$newname" ]; then
+        mv "$_CACHE_DIR/$1" "$_CACHE_DIR/$newname"
     fi
+
+    echo "$newname"
+}
+
+rename_gui() {
+    yad --entry --title "NextShot" --borders=10 --button="gtk-save" --entry-text="$1" \
+        --text="<b>Screenshot Saved!</b>\nEnter filename to save to NextCloud:" 2>/dev/null
 }
 
 nc_upload() {

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -453,7 +453,8 @@ shoot_x() {
 attempt_rename() {
     local newname
 
-    if [ "$rename" = true ] && has yad; then newname="$(rename_gui "$1")"
+    if [ "$rename" = true ] && is_interactive; then newname="$(rename_cli "$1")"
+    elif [ "$rename" = true ] && has yad; then newname="$(rename_gui "$1")"
     else newname="$1"; fi
 
     if [ ! "$1" = "$newname" ]; then
@@ -461,6 +462,11 @@ attempt_rename() {
     fi
 
     echo "$newname"
+}
+
+rename_cli() {
+    read -rp "Screenshot saved!\nEnter filename [$1]: " newname
+    echo "${newname:-$1}"
 }
 
 rename_gui() {


### PR DESCRIPTION
Reworks the `attempt_rename` function to be clearer, abstracts the Yad
prompt and adds a new CLI-based prompt to allow for taking screenshots
without leaving the terminal.

Closes #43.