### PR TITLE
Add support for overriding environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-* CLI prompt for renaming screenshots when running interactively
+* Ability to force environment with `NEXTSHOT_ENV` var or `--env` flag
+
+### Changed
+* Filename prompt now uses CLI instead of Yad when running interactively
 
 ### Fixed
 * Quit item in tray menu didn't actually quit

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ compatibility with compositors other than Sway.
 * [Configuration](#configuration)
   * [Example nextshot.conf](#example-nextshotconf)
   * [Available Options](#available-options)
+* [Troubleshooting](#troubleshooting)
 * [Known Issues](#known-issues)
 
 ## Installation
@@ -245,6 +246,33 @@ It should be specified as comma-separated RGB so that Nextshot can parse the ind
 values and pass them along to either Slop or Slurp, depending on whether you use X11 or Wayland.
 
 Defaults to `255,100,180`.
+
+## Troubleshooting
+
+#### Nextshot is detecting the wrong environment
+
+In some cases it may be that Nextshot's environment detection doesn't quite work as expected. One
+example of this might be if your system has both X11 *and* Wayland. If you were to start a tmux
+session under X11 then switch to Wayland and run Nextshot from within tmux, it will think you're
+running under the X11 environment when that's not really the case.
+
+To fix this you can bypass the default detection method:
+```sh
+nextshot --env=wayland ...
+```
+
+For a more permanent fix, you can set or `export` the `NEXTSHOT_ENV` environment variable:
+```sh
+export NEXTSHOT_ENV=wayland
+nextshot ...
+
+# or
+
+NEXTSHOT_ENV=wayland nextshot ...
+```
+
+Likewise if you're running from X11 but Nextshot detects Wayland, you can set `--env` or
+`NEXTSHOT_ENV` to `x11`. For more details and possible values, see `nextshot --help`.
 
 ## Known Issues
 

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -160,7 +160,7 @@ setup() {
 
 parse_opts() {
     local -r OPTS=D::htVawd:fpc
-    local -r LONG=deps::,dependencies::,help,tray,version,area,window,delay:,fullscreen,paste,file:,clipboard
+    local -r LONG=deps::,dependencies::,env:,help,tray,version,area,window,delay:,fullscreen,paste,file:,clipboard
     local parsed
 
     ! parsed=$(getopt -o "$OPTS" -l "$LONG" -n "$0" -- "$@")
@@ -187,6 +187,20 @@ parse_opts() {
                         is_wayland && chk="w" || chk="x" ;;
                 esac
                 status_check "$chk" && exit 0 ;;
+            --env)
+                NC_ENV=${2//=}
+                case "${NC_ENV,,}" in
+                    w|wl|way|wayland)
+                        NC_ENV=wayland ;;
+                    x|x11)
+                        NC_ENV=x11 ;;
+                    auto)
+                        ;;
+                    *)
+                        echo "Invalid environment. Valid options include 'auto', 'wayland' or 'x11'."
+                        exit 1 ;;
+                esac
+                shift 2 ;;
             -h|--help)
                 usage && exit 0 ;;
             -t|--tray)
@@ -241,6 +255,12 @@ parse_opts() {
     : ${mode:=selection}
     echo "Screenshot mode set to $mode"
     echo "Output will be sent to ${output_mode^}"
+
+    [ -n "${NC_ENV+x}" ] || autoset_environment
+}
+
+autoset_environment() {
+    NC_ENV="$(is_wayland_detected && echo "wayland" || echo "x11")"
 }
 
 delay_capture() {
@@ -260,6 +280,10 @@ is_interactive() {
 }
 
 is_wayland() {
+    [ "$NC_ENV" = "wayland" ]
+}
+
+is_wayland_detected() {
     [ -n "${WAYLAND_DISPLAY+x}" ]
 }
 

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -173,6 +173,7 @@ parse_opts() {
     while true; do
         case "$1" in
             -D|--deps|--dependencies)
+                [ -n "${NC_ENV+x}" ] || autoset_environment
                 local chk=${2//=}
                 case "${chk,,}" in
                     a|all)
@@ -325,7 +326,8 @@ status_check() {
     echo
     echo "Current version: Nextshot v${_VERSION}"
     echo -n "Detected environment: "
-    is_wayland && echo "Wayland" || echo "X11"
+    is_wayland_detected && echo "Wayland" || echo "X11"
+    echo "Active environment: ${NC_ENV^}"
     echo
 
     echo "Global dependencies"; check_deps "${reqG[@]}"; echo

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -35,6 +35,7 @@ usage() {
     echo
     echo "General Options:"
     echo "  -D, --deps[=TYPE] List dependency statuses and exit"
+    echo "  --env=ENV         Override environment detection"
     echo "  -h, --help        Display this help and exit"
     echo "  -t, --tray        Start the NextShot tray menu"
     echo "  -V, --version     Output version information and exit"
@@ -74,6 +75,11 @@ usage() {
     echo "dependencies. When omitted, dependencies are listed based on"
     echo "the currently active environment as detected by Nextshot."
     echo "Note that TYPE is case-insensitive. -DA is the same as -Da."
+    echo; echo
+    echo "The --env flag affects the tools used to take screenshots."
+    echo "ENV can be one of 'w', 'wl' or 'wayland' to force Wayland"
+    echo "mode; 'x' or 'x11' to force X11; 'auto' or left blank to"
+    echo "use the builtin automatic environment detection."
     echo
 }
 


### PR DESCRIPTION
Adds a new optional `--env` flag which accepts values `x` or `x11` to force X11; `w`, `wl`, `way` or `wayland` to force Wayland; or `auto` to use the existing automatic detection.

Should fix any issues running inside terminal multiplexers such as Tmux where the session was started in a different environment to the one that's currently running.

For example, if you start the tmux server under X11 when the PC boots, then switch to Wayland and run Nextshot from within tmux, it would normally detect the X11 session and attempt to use X-based tools before failing. By running `nextshot --env=wayland`, Nextshot will not attempt to use X-only tools such as Slop and Xclip.

Closes #36.