### PR TITLE
Add `-v, --verbose` option to enable debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 * Ability to force environment with `NEXTSHOT_ENV` var or `--env` flag
+* Debug mode for detailed output, enabled with `-v, --verbose`
 
 ### Changed
 * Filename prompt now uses CLI instead of Yad when running interactively

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Ability to force environment with `NEXTSHOT_ENV` var or `--env` flag
 * Debug mode for detailed output, enabled with `-v, --verbose`
+* Basic error handling in case of issues when sharing a screenshot
 
 ### Changed
 * Filename prompt now uses CLI instead of Yad when running interactively

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -522,7 +522,7 @@ rename_gui() {
 }
 
 nc_upload() {
-    local filename output respCode; read -r filename
+    local filename output respCode url; read -r filename
 
     echo -e "\nUploading screenshot..." >&2
 
@@ -536,6 +536,8 @@ nc_upload() {
         echo "Upload failed. Expected 201 but server returned a $respCode response" >&2 && exit 1
     fi
 
+    url="$server/apps/gallery/#${savedir}/$filename"
+    echo "Screenshot uploaded to ${url// /%20}" >&2
     echo "$filename"
 }
 
@@ -619,9 +621,8 @@ send_notification() {
     if has notify-send; then
         notify-send -u normal -t 5000 -i insert-link NextShot \
             "${1:-"<a href=\"$url\">Your link</a> is ready to paste!"}"
-    else
-        echo "${1:-"Link $url copied to clipboard. Paste away!"}"
     fi
+    echo "${1:-"Copied $url to clipboard. Paste away!"}"
 }
 
 config_cli() {


### PR DESCRIPTION
Updates the curl upload command to support redirecting output to a file
when debug mode is enabled so that it can be shown with the "Upload
failed" error to help troubleshoot issues such as #54.

While we could simply send output to STDERR with `-o /dev/stderr`, the
output ends up looking a bit off because there's no `\n` after the
progress bar, making it difficult to read the error.

In future it would be nice to parse the XML returned from Nextcloud, but
displaying the raw response should suffice for now.