### PR TITLE
Fix 400 bad request on upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Fixed
+* Issue on some systems that caused spaces in filename to break upload
 
 
 ## [1.2.1] - 2019-06-08

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -523,12 +523,15 @@ rename_gui() {
 }
 
 nc_upload() {
-    local filename output respCode url; read -r filename
+    local filename output respCode reqUrl url; read -r filename
 
     echo -e "\nUploading screenshot..." >&2
 
+    reqUrl="$server/remote.php/dav/files/$username/$savedir/$filename"
     [ $debug = true ] && output="$_CACHE_DIR/curlout" || output=/dev/null
-    respCode=$(curl -u "$username":"$password" "$server/remote.php/dav/files/$username/$savedir/$filename" \
+    [ $debug = true ] && echo "Sending request to ${reqUrl}..." >&2
+
+    respCode=$(curl -u "$username":"$password" "$reqUrl" \
         -L --post301 --upload-file "$_CACHE_DIR/$filename" -#o $output -w "%{http_code}")
 
     if [ "$respCode" = 204 ]; then
@@ -547,7 +550,7 @@ nc_upload() {
 
 nc_share() {
     local json respCode
-    [ $debug = true ] && echo -e "\nApplying share settings..." >&2
+    [ $debug = true ] && echo -e "\nApplying share settings to $savedir/$1..." >&2
 
     respCode=$(curl -u "$username":"$password" -X POST --post301 -sSLH "OCS-APIRequest: true" \
         "$server/ocs/v2.php/apps/files_sharing/api/v1/shares?format=json" \

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -527,7 +527,7 @@ nc_upload() {
 
     echo -e "\nUploading screenshot..." >&2
 
-    reqUrl="$server/remote.php/dav/files/$username/$savedir/$filename"
+    reqUrl="$server/remote.php/dav/files/$username/$savedir/${filename// /%20}"
     [ $debug = true ] && output="$_CACHE_DIR/curlout" || output=/dev/null
     [ $debug = true ] && echo "Sending request to ${reqUrl}..." >&2
 


### PR DESCRIPTION
Replaces any spaces in the screenshot filename with `%20` to hopefully solve #54 where the URL gets broken before reaching Nextcloud, causing a `400 Bad Request` error.

Fixes #54.