### PR TITLE
Add ability to override format at runtime and in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 * Active config values are now shown as part of verbose output
-* Default file extension can now be set in config eg `format=jpg`
+* File extension can now be set with `format` in config and/or at runtime
 
 
 ## [1.3.2] - 2020-04-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 * Active config values are now shown as part of verbose output
+* Default file extension can now be set in config eg `format=jpg`
 
 
 ## [1.3.2] - 2020-04-06

--- a/README.md
+++ b/README.md
@@ -222,6 +222,15 @@ Defaults to `false`
 
 ---
 
+#### `format` - optional
+
+Set the default image format and file extension for saving screenshots.  
+Supported values are `png`, `jpg` or `jpeg`.
+
+Defaults to `png`.
+
+---
+
 #### `rename` - optional
 
 When you set this option to `true`, Nextshot will prompt you to enter a custom filename before

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -342,6 +342,10 @@ is_format() {
     [[ "${1,,}" =~ ^png|jpe?g$ ]]
 }
 
+is_jpeg() {
+    [[ "${format}" =~ ^jpe?g$ ]]
+}
+
 is_wayland() {
     [ "$NEXTSHOT_ENV" = "wayland" ]
 }
@@ -442,7 +446,7 @@ to_clipboard() {
     local mime
 
     [ "${1:-text}" = "image" ] && (
-        [[ "${format}" =~ ^jpe?g$ ]] && mime="image/jpeg" || mime="image/png"
+        is_jpeg && mime="image/jpeg" || mime="image/png"
     ) || mime="text/plain"
 
     if is_wayland; then wl-copy -t $mime
@@ -539,11 +543,7 @@ shoot_wayland() {
         args=(-g "$(select_window)")
     fi
 
-    if [[ "${format}" =~ ^jpe?g$ ]]; then
-        args+=(-t jpeg)
-    else
-        args+=(-t png)
-    fi
+    is_jpeg && args+=(-t jpeg) || args+=(-t png)
 
     delay_capture
     grim "${args[@]}" "$1"

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -55,6 +55,7 @@ usage() {
     echo "  -f, --fullscreen  Capture the entire X/Wayland display"
     echo "  -w, --window      Capture a single window"
     echo "  -d, --delay=NUM   Pause for NUM seconds before capture"
+    echo "  -F, --format=FMT  Save image as FMT instead of the default"
     echo
     echo "Upload Modes:"
     echo
@@ -172,8 +173,8 @@ setup() {
 }
 
 parse_opts() {
-    local -r OPTS=D::htvVawd:fpc
-    local -r LONG=deps::,dependencies::,env:,help,tray,prune-cache,verbose,version,area,window,delay:,fullscreen,paste,file:,clipboard
+    local -r OPTS=D::htvVawd:F:fpc
+    local -r LONG=deps::,dependencies::,env:,help,tray,prune-cache,verbose,version,area,window,delay:,format:,fullscreen,paste,file:,clipboard
     local parsed
 
     ! parsed=$(getopt -o "$OPTS" -l "$LONG" -n "$0" -- "$@")
@@ -228,6 +229,8 @@ parse_opts() {
                 mode="window"; shift ;;
             -d|--delay)
                 delay=${2//=}; shift 2 ;;
+            -F|--format)
+                format=${2//=}; shift 2 ;;
             --file)
                 local mimetype
 

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -231,7 +231,7 @@ parse_opts() {
                 delay=${2//=}; shift 2 ;;
             -F|--format)
                 cliFormat=${2//=}
-                if ! [[ "${cliFormat}" =~ ^png|jpe?g$ ]]; then
+                if ! is_format "${cliFormat}"; then
                     echo "WARNING: Invalid image format '${cliFormat}', default will be set from config."
                 fi
                 shift 2 ;;
@@ -336,6 +336,10 @@ has() {
 # shellcheck disable=SC2009
 is_interactive() {
     ps -o stat= -p $$ | grep -q '+'
+}
+
+is_format() {
+    [[ "${1,,}" =~ ^png|jpe?g$ ]]
 }
 
 is_wayland() {
@@ -465,10 +469,10 @@ load_config() {
     rename=${rename,,}
     delay=${delay:-0}
 
-    if [[ "${cliFormat}" =~ png|jpe?g$ ]]; then
-        format="${cliFormat}"
+    if is_format "${cliFormat}"; then
+        format="${cliFormat,,}"
     else
-        [[ "${format}" =~ ^png|jpe?g$ ]] || format="png"
+        is_format "${format}" && format="${format,,}" || format="png"
     fi
 
     if [ $debug = true ]; then

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -230,7 +230,11 @@ parse_opts() {
             -d|--delay)
                 delay=${2//=}; shift 2 ;;
             -F|--format)
-                format=${2//=}; shift 2 ;;
+                cliFormat=${2//=}
+                if ! [[ "${cliFormat}" =~ ^png|jpe?g$ ]]; then
+                    echo "WARNING: Invalid image format '${cliFormat}', default will be set from config."
+                fi
+                shift 2 ;;
             --file)
                 local mimetype
 
@@ -454,13 +458,18 @@ load_config() {
     : "${server:?$errmsg}" "${username:?$errmsg}" "${password:?$errmsg}" "${savedir:?$errmsg}"
     [ $debug = true ] && echo "Uploading to /${savedir} as ${username} on Nextcloud instance ${server}"
 
-    format="${format:-png}"
     hlColour="$(parse_colour "${hlColour:-255,100,180}")"
     link_previews=${link_previews:-false}
     link_previews=${link_previews,,}
     rename=${rename:-false}
     rename=${rename,,}
     delay=${delay:-0}
+
+    if [[ "${cliFormat}" =~ png|jpe?g$ ]]; then
+        format="${cliFormat}"
+    else
+        [[ "${format}" =~ ^png|jpe?g$ ]] || format="png"
+    fi
 
     if [ $debug = true ]; then
         echo -e "\nParsed config:"


### PR DESCRIPTION
Adds a new `format` option in the config file which will set the default image type and file extension. Valid values are either `png`, `jpg` or `jpeg` and are case insensitive. If no value is provided, the default is png.

Config (or the default) can be overridden at runtime with the `-F` or `--format` arg which takes the desired image type as its value, eg `-Fpng` or `--format=jpg`.

Closes #20 