### PR TITLE
Better sway selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Active config values are now shown as part of verbose output
 * File extension can now be set with `format` in config and/or at runtime
 
+### Changed
+* Window selection on Sway is now via Slurp instead of a list
+
 
 ## [1.3.2] - 2020-04-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * Window selection on Sway is now via Slurp instead of a list
 
+### Fixed
+* Floating windows weren't able to be selected on Sway
+
 
 ## [1.3.2] - 2020-04-06
 ### Fixed

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -540,7 +540,7 @@ shoot_wayland() {
     if [ "$mode" = "selection" ]; then
         args=(-g "$(slurp -d -c "${hlColour}ee" -s "${hlColour}66")")
     elif [ "$mode" = "window" ]; then
-        windows="$(swaymsg -t get_tree | jq -r '.. | (.nodes? // empty)[] | select(.visible and .pid) | .rect | "\(.x),\(.y) \(.width)x\(.height)"')"
+        windows="$(swaymsg -t get_tree | jq -r '.. | select(.visible? and .pid?) | .rect | "\(.x),\(.y) \(.width)x\(.height)"')"
         args=(-g "$(slurp -d -c "${hlColour}ee" -s "${hlColour}66" <<< "${windows}")")
     fi
 


### PR DESCRIPTION
Replaces the CLI/Yad window selection menus with slurp-based selection similar to what we get with Slop in X11. Also fixes an issue where extraneous filtering in the `jq` call were preventing floating windows from being selected on Sway.