### PR TITLE
Support Nextcloud instances that have Pretty URLs disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Active config values are now shown as part of verbose output
 * File extension can now be set with `format` in config and/or at runtime
+* New `pretty_urls` config option to support Nextcloud servers that require `/index.php`
 
 ### Changed
 * Window selection on Sway is now via Slurp instead of a list

--- a/README.md
+++ b/README.md
@@ -220,6 +220,16 @@ clicking the link will take you directly to the full-size image rather than Next
 
 Defaults to `false`
 
+
+---
+
+#### `pretty_urls` - optional
+
+When disabled (set to `false`), this will insert `/index.php` in share links, after the Server URL.  
+Leave this set to `true` (enabled) if your Nextcloud server has Pretty URLs enabled.
+
+Defaults to `true`
+
 ---
 
 #### `format` - optional

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -494,7 +494,8 @@ load_config() {
         echo "  format: ${format}"
         echo "  rename: ${rename}"
         echo "  hlColour: ${hlColour}"
-        echo -e "  link_previews: ${link_previews}\n"
+        echo "  link_previews: ${link_previews}"
+        echo -e "  pretty_urls: ${pretty_urls}\n"
     fi
 }
 
@@ -685,22 +686,26 @@ Fill out the options below and you'll be taking screenshots in no time:\n" \
         --field="To generate an App Password, open your Nextcloud instance.
 Under <b>Settings > Personal > Security</b>, enter <i>\"NextShot\"</i> for the App name
 and click <b>Create new app password</b>.\n:LBL" \
+        --field="Enable Pretty URLs:CHK" \
+        --field="When disabled, 'index.php' will be added to links that need it.\n:LBL" \
         --field="Link direct to image instead of Nextcloud UI (appends '/preview'):CHK" \
         --field="Prompt to rename screenshots before upload:CHK" \
         --field="Screenshot Folder" \
         --field="This is where screenshots will be uploaded on Nextcloud, relative to your user root.\n:LBL" \
-        "https://" "" "" "" "" false true "Screenshots") || config_abort
+        "https://" "" "" "" "" true "" false true "Screenshots") || config_abort
 
-    IFS='|' read -r server _ username password _ link_previews rename savedir _ <<< "$response"
+    IFS='|' read -r server _ username password _ pretty_urls _ link_previews rename savedir _ <<< "$response"
     link_previews=${link_previews//\'/}
     link_previews=${link_previews,,}
+    pretty_urls=${pretty_urls//\'/}
+    pretty_urls=${pretty_urls,,}
     rename=${rename//\'/}
     rename=${rename,,}
 
     config=$(yad --title="NextShot Configuration" --borders=10 --separator='' \
         --text="Check the config below and correct any errors before saving:" --fixed\
-        --button="Cancel!window-close:1" --button="Save!document-save:0" --width=400 --height=175 --form --field=":TXT" \
-        "server=$server\nusername=$username\npassword=$password\nsavedir=$savedir\nlink_previews=$link_previews\nrename=$rename") || config_abort
+        --button="Cancel!window-close:1" --button="Save!document-save:0" --width=400 --height=185 --form --field=":TXT" \
+        "server=$server\nusername=$username\npassword=$password\npretty_urls=$pretty_urls\nsavedir=$savedir\nlink_previews=$link_previews\nrename=$rename") || config_abort
 
     echo -e "${config}" > "$_CONFIG_FILE"
 }
@@ -735,6 +740,10 @@ username=''
 
 # Nextcloud App Password created specifically for NextShot (Settings > Personal > Security)
 password=''
+
+# Does your server have Pretty URLs enabled?
+#  Set this to false if links include 'index.php'
+pretty_urls=true
 
 # Folder on Nextcloud where screenshots will be uploaded (must already exist)
 savedir=''

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -122,7 +122,11 @@ tray_menu() {
         exit 1
     fi
 
-    load_config && local files_url="$server/apps/files/?dir=/$savedir"
+    load_config && local files_url prefix
+    if ! $pretty_urls; then
+        prefix=/index.php
+    fi
+    files_url="${server}${prefix}/apps/files/?dir=/${savedir}"
 
     echo "Starting Nextshot tray menu..." >&2
     rm -f "$_TRAY_FIFO"; mkfifo "$_TRAY_FIFO" && exec 3<> "$_TRAY_FIFO"
@@ -599,7 +603,7 @@ rename_gui() {
 }
 
 nc_upload() {
-    local filename output respCode reqUrl url; read -r filename
+    local filename output respCode reqUrl prefix url; read -r filename
 
     echo -e "\nUploading screenshot..." >&2
 
@@ -619,7 +623,10 @@ nc_upload() {
         echo "Upload failed. Expected 201 but server returned a $respCode response" >&2 && exit 1
     fi
 
-    url="$server/apps/gallery/#${savedir}/$filename"
+    if ! $pretty_urls; then
+        prefix=/index.php
+    fi
+    url="${server}${prefix}/apps/gallery/#${savedir}/$filename"
     echo "Screenshot uploaded to ${url// /%20}" >&2
     echo "$filename"
 }

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -363,13 +363,16 @@ int2hex() {
 }
 
 make_url() {
-    local json suffix; read -r json
+    local json prefix suffix; read -r json
 
     if $link_previews; then
         suffix=/preview
     fi
+    if ! $pretty_urls; then
+        prefix=/index.php
+    fi
 
-    echo "$server/s/$(echo "$json" | jq -r '.ocs.data.token')${suffix}"
+    echo "${server}${prefix}/s/$(echo "$json" | jq -r '.ocs.data.token')${suffix}"
 }
 
 status_check() {
@@ -469,6 +472,8 @@ load_config() {
     hlColour="$(parse_colour "${hlColour:-255,100,180}")"
     link_previews=${link_previews:-false}
     link_previews=${link_previews,,}
+    pretty_urls=${pretty_urls:-true}
+    pretty_urls=${pretty_urls,,}
     rename=${rename:-false}
     rename=${rename,,}
     delay=${delay:-0}

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -372,11 +372,14 @@ make_share_url() {
 }
 
 make_url() {
-    if [ "${*:0:1}" = "/" ] && ! $pretty_urls; then
-        echo "${server}/index.php${*}"
-    else
-        echo "${server}/${*}"
+    local path="$*";
+    if ! [ "${path:0:1}" = "/" ]; then
+        echo "${server}/${path}"
+        return
     fi
+
+    $pretty_urls && echo "${server}${*}" \
+        || echo "${server}/index.php${*}"
 }
 
 status_check() {


### PR DESCRIPTION
Adds a new `pretty_urls` config option to fix an issue with broken upload and share links.

Servers that don't support (or have disabled) pretty URLs require `/index.php` to be inserted in links after the server domain, but Nextshot wasn't adding them. You couldn't just add it to the `server` option in config because that would break the API calls.

When `pretty_urls` is set to `false` in config (it's `true` by default) this will now add `/index.php` where appropriate.

Fixes #67 