### PR TITLE
Current display support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Active config values are now shown as part of verbose output
 * File extension can now be set with `format` in config and/or at runtime
 * New `pretty_urls` config option to support Nextcloud servers that require `/index.php`
+* Screenshot the active display with `nextshot --monitor`, or `-m` for short
 
 ### Changed
 * Window selection on Sway is now via Slurp instead of a list

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ based on your environment:
 
 ```sh
 # To use in i3 (or other X11-based environments)
-sudo pacman -S --asdeps imagemagick slop xclip yad
+sudo pacman -S --asdeps imagemagick slop xclip xdotool yad
 
 # To use in Sway
 sudo pacman -S --asdeps grim slurp wl-clipboard yad
@@ -75,16 +75,16 @@ To have Nextshot's primary functions bound to the Print Screen key on i3 and Swa
 to your `config` file in `~/.config/i3` and/or `~/.config/sway` respectively:
 
 ```
-bindsym Print exec --no-startup-id "nextshot -f"
+bindsym Print exec --no-startup-id "nextshot -m"
 bindsym Mod4+Print exec --no-startup-id "nextshot -w"
 bindsym Shift+Print exec --no-startup-id "nextshot -a"
 
-bindsym Ctrl+Print exec --no-startup-id "nextshot -fc"
+bindsym Ctrl+Print exec --no-startup-id "nextshot -mc"
 bindsym Ctrl+Mod4+Print exec --no-startup-id "nextshot -wc"
 bindsym Ctrl+Shift+Print exec --no-startup-id "nextshot -ac"
 ```
 
-These bindings will have `PrtScr` capture the full screen, `Shift+PrtScr` capture an area, and
+These bindings will have `PrtScr` capture the current screen, `Shift+PrtScr` capture an area, and
 `Super+PrtScr` capture a window—each uploading automatically to Nextcloud and copying the
 share link to your clipboard.
 
@@ -109,7 +109,11 @@ bypass Nextcloud and instead copy the image to clipboard, add the `-c` or `--cli
 
     `nextshot -w` or `nextshot --window`
 
-* **Capture the entire desktop**
+* **Capture the active display**
+
+    `nextshot -m` or `nextshot --monitor`
+
+* **Capture *all* outputs**
 
     `nextshot -f` or `nextshot --fullscreen`
 

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -556,6 +556,8 @@ shoot_wayland() {
 
     if [ "$mode" = "selection" ]; then
         args=(-g "$(slurp -d -c "${hlColour}ee" -s "${hlColour}66")")
+    elif [ "$mode" = "monitor" ]; then
+        args=(-g "$(swaymsg -t get_workspaces | jq -r '.[] | select(.focused) | .rect | "\(.x),\(.y) \(.width)x\(.height)"')")
     elif [ "$mode" = "window" ]; then
         windows="$(swaymsg -t get_tree | jq -r '.. | select(.visible? and .pid?) | .rect | "\(.x),\(.y) \(.width)x\(.height)"')"
         args=(-g "$(slurp -d -c "${hlColour}ee" -s "${hlColour}66" <<< "${windows}")")
@@ -575,7 +577,6 @@ shoot_x() {
     if [ "$mode" = "fullscreen" ]; then
         args=(-window root)
     elif [ "$mode" = "monitor" ]; then
-        echo "Selection set to curent display" >&2
         local mouse mouseX mouseY monitors geometry
 
         # Find current cursor position

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -136,6 +136,7 @@ tray_menu() {
 Open Nextcloud      ! xdg-open $files_url !emblem-web||\
 Capture area        ! nextshot -a         !window-maximize-symbolic|\
 Capture window      ! nextshot -w         !window-new|\
+Capture monitor     ! nextshot -m         !display|\
 Capture full screen ! nextshot -f         !view-fullscreen-symbolic||\
 Paste from Clipboard! nextshot -p         !edit-paste-symbolic||\
 Quit Nextshot       ! kill $traypid       !application-exit" >&3
@@ -575,7 +576,7 @@ shoot_x() {
         args=(-window root)
     elif [ "$mode" = "monitor" ]; then
         echo "Selection set to curent display" >&2
-        local mouse mouseX mouseY monitors
+        local mouse mouseX mouseY monitors geometry
 
         # Find current cursor position
         mouse="$(xdotool getmouselocation)"
@@ -607,9 +608,12 @@ shoot_x() {
                 continue
             fi
 
+            geometry="${monW}x${monH}+${monX}+${monY}"
             [ $debug = true ] && echo "Found active monitor: ${monN}" >&2
             break
         done
+
+        args=(-window root -crop "$geometry")
     elif [ "$mode" = "selection" ]; then
         args=(-window root -crop "$($slop -f "%g" -t 0)")
     elif [ "$mode" = "window" ]; then


### PR DESCRIPTION
Adds a new `--monitor` mode that detects the display the cursor is positioned within before capturing only that display.

Since upstream tools don't really support active monitor detection, we get the cursor position using `xdotool` then loop through the outputs until the cursor position is within the output coordinates. That's then formed into a geometry string which can be passed to `import` for cropping from the root window.

Fixes #13 