### PR TITLE
Fix/catch missing deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 * Worked around Yad ignoring tray icon if the tray isn't visible
+* Missing env-specific dependencies weren't checked before being run
 
 
 ## [1.4.1] - 2020-08-13

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -576,16 +576,22 @@ shoot_wayland() {
     local args windows
 
     if [ "$mode" = "selection" ]; then
-        args=(-g "$(slurp -d -c "${hlColour}ee" -s "${hlColour}66")")
+        prefers slurp
+        has slurp && args=(-g "$(slurp -d -c "${hlColour}ee" -s "${hlColour}66")")
     elif [ "$mode" = "monitor" ]; then
-        args=(-g "$(swaymsg -t get_workspaces | jq -r '.[] | select(.focused) | .rect | "\(.x),\(.y) \(.width)x\(.height)"')")
+        prefers swaymsg
+        has swaymsg && \
+            args=(-g "$(swaymsg -t get_workspaces | jq -r '.[] | select(.focused) | .rect | "\(.x),\(.y) \(.width)x\(.height)"')")
     elif [ "$mode" = "window" ]; then
+        prefers slurp
+        requires swaymsg
         windows="$(swaymsg -t get_tree | jq -r '.. | select(.visible? and .pid?) | .rect | "\(.x),\(.y) \(.width)x\(.height)"')"
-        args=(-g "$(slurp -d -c "${hlColour}ee" -s "${hlColour}66" <<< "${windows}")")
+        has slurp && args=(-g "$(slurp -d -c "${hlColour}ee" -s "${hlColour}66" <<< "${windows}")")
     fi
 
     is_jpeg && args+=(-t jpeg) || args+=(-t png)
 
+    requires grim
     delay_capture
     grim "${args[@]}" "$1"
 }

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -579,6 +579,9 @@ shoot_x() {
 
     slop="slop -c $hlColour,0.4 -lb 3"
 
+    has slop || echo -e "WARNING: Slop is required for most capture modes.\nRun nextshot -D to check dependencies." >&2
+    has import || { echo -e "ERROR: import command is missing.\nRun nextshot -D To check dependencies." >&2; exit 1; }
+
     if [ "$mode" = "fullscreen" ]; then
         args=(-window root)
     elif [ "$mode" = "monitor" ]; then


### PR DESCRIPTION
Checks that certain commands exist before using them to avoid "command not found" type errors breaking it.

Some packages are "required" and will abort Nextshot if missing, while others are only "preferred".  
Preferred packages *can* be absent, but usually result in e.g. geometries not passed to the capturing command.

Fixes #71