### PR TITLE
Delay clipboard check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Worked around Yad ignoring tray icon if the tray isn't visible
 * Missing env-specific dependencies weren't checked before being run
 * Checking clipboard too early caused accidental xclip error on Wayland
+* Dependency on wl-clipboard is now detected correctly by the -D check
 
 
 ## [1.4.1] - 2020-08-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Worked around Yad ignoring tray icon if the tray isn't visible
 * Missing env-specific dependencies weren't checked before being run
+* Checking clipboard too early caused accidental xclip error on Wayland
 
 
 ## [1.4.1] - 2020-08-13

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -463,8 +463,11 @@ check_dep() {
 check_clipboard() {
     local cmd
 
-    if is_wayland; then cmd="wl-paste -l"
+    if is_wayland; then
+        require wl-paste
+        cmd="wl-paste -l"
     else
+        require xclip
         cmd="xclip -selection clipboard -o -t TARGETS"
     fi
 
@@ -485,11 +488,16 @@ to_clipboard() {
         is_jpeg && mime="image/jpeg" || mime="image/png"
     fi
 
-    if is_wayland; then wl-copy -t $mime
-    elif [ "${mime}" == "text/plain" ]; then
-        xclip -selection clipboard
+    if is_wayland; then
+        require wl-copy
+        wl-copy -t $mime
     else
-        xclip -selection clipboard -t "${mime}"
+        require xclip
+        if [ "${mime}" == "text/plain" ]; then
+            xclip -selection clipboard
+        else
+            xclip -selection clipboard -t "${mime}"
+        fi
     fi
 }
 

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -100,6 +100,11 @@ nextshot() {
     parse_environment
     load_config
 
+    if [ "$mode" = "clipboard" ] && ! check_clipboard; then
+        echo "Clipboard does not contain an image, aborting."
+        exit 1
+    fi
+
     image=$(cache_image)
 
     if [ "$output_mode" = "clipboard" ]; then
@@ -259,10 +264,6 @@ parse_opts() {
                 fi
                 shift 2 ;;
             -p|--paste)
-                if ! check_clipboard; then
-                    echo "Clipboard does not contain an image, aborting."
-                    exit 1
-                fi
                 mode="clipboard"; shift ;;
             -c|--clipboard)
                 output_mode="clipboard"; shift ;;

--- a/nextshot.sh
+++ b/nextshot.sh
@@ -417,7 +417,7 @@ status_check() {
     local reqW=(
         "grim           grim         to take screenshots"
         "slurp          slurp        for area selection"
-        "wl-clipboard   wl-clipboard to interact with the clipboard"
+        "wl-copy        wl-clipboard to interact with the clipboard"
     )
     local reqX=(
         "slop   slop        for window and area selection"


### PR DESCRIPTION
Args are parsed before the environment, so clipboard cannot be checked
until later or it will always check for xclip in Wayland when env isn't
manually being set with --env or NEXTSHOT_ENV.

Fixes #75 