### PR TITLE
GitHub Actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release-tagged:
+    name: Build release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Generate Changelog
+        run: |
+          TAG="${GITHUB_REF_NAME//./\.}"
+          echo "Generating changelog for ${TAG}..."
+          sed -n "/^## \[${TAG/v/}\]/,/^## \[/{//b;p}" CHANGELOG.md > ${{ github.workspace }}-changes.md
+          cat ${{ github.workspace }}-changes.md
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: ${{ github.workspace }}-changes.md

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,0 +1,16 @@
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [master, develop]
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run Shellcheck
+        uses: ludeeus/action-shellcheck@master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: bash
-script:
-  - bash -c 'shopt -s globstar; shellcheck **/*.sh'


### PR DESCRIPTION
Replaces the old travis config with a GH Actions workflow for shellcheck, and adds one for releases.