### PR TITLE
Prompt before overwriting files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Added
+* NextCloud uploads can now be aborted if they would overwrite an existing file
 
 
 ## [1.4.4] - 2023-05-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-* NextCloud uploads can now be aborted if they would overwrite an existing file
+* NextCloud uploads can now be aborted or renamed if they would overwrite another file
 
 
 ## [1.4.4] - 2023-05-05

--- a/src/main.bash
+++ b/src/main.bash
@@ -106,7 +106,7 @@ usage() {
 }
 
 main() {
-    local debug=false image filename json url
+    local debug=false image filename json ncfilename url
     output_mode="nextcloud"
 
     check_bash_version && setup
@@ -126,7 +126,8 @@ main() {
         to_clipboard image < "$_CACHE_DIR/$image" && \
             send_notification "Your image is ready to paste!"
     else
-        filename="$(echo "$image" | nc_upload)"
+        ncfilename="$(nc_overwrite_check "$image")"
+        filename="$(echo "$image" | nc_upload "$ncfilename")"
 
         json=$(nc_share "$filename")
         url="$(echo "$json" | make_share_url)"

--- a/src/main.bash
+++ b/src/main.bash
@@ -129,7 +129,7 @@ main() {
         ncfilename="$(nc_overwrite_check "$image")"
         filename="$(echo "$image" | nc_upload "$ncfilename")"
 
-        json=$(nc_share "$filename")
+        json=$(nc_share "$ncfilename")
         url="$(echo "$json" | make_share_url)"
 
         echo "$url" | to_clipboard && send_notification


### PR DESCRIPTION
This implements some of the functionality from #60.

Before uploading a screenshot, this sends a `PROPFIND` request to figure out whether another file already exists with the same name in NextCloud.

If there's a conflict, upload will be interrupted by a new prompt in both CLI and GUI modes.

Available options:
* Replace (default in GUI mode)
* Overwrite (previous behaviour)
* Abort