### PR TITLE
feat: use spectacle for kde on wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Nextcloud (the default) so you can paste the public link in chats.
 From the start, the primary goal has been to work with both i3 and Sway. Since the release
 of  1.0, this has largely been achieved. While Nextshot will work on Sway and likely most
 X11-based environments, the nature of Wayland means extra work will be required for eventual
-compatibility with compositors other than Sway.
+compatibility with compositors other than Sway. Wayland on KDE works by using spectacle for 
+selection and capture.
 
 *TL;DR: YMMV*
 
@@ -56,6 +57,9 @@ sudo pacman -S --asdeps imagemagick slop xclip xdotool yad
 
 # To use in Sway
 sudo pacman -S --asdeps grim slurp wl-clipboard yad
+
+# To use in KDE w/ Wayland
+sudo pacman -S --asdeps wl-clipboard yad spectacle
 ```
 
 For more information on dependencies, run `nextshot --deps` after install.

--- a/src/_capture.bash
+++ b/src/_capture.bash
@@ -67,7 +67,13 @@ take_screenshot() {
     if [ "$mode" = "clipboard" ]; then
         from_clipboard > "$filepath"
     else
-        is_wayland && shoot="shoot_wayland" || shoot="shoot_x"
+        if is_wayland && is_plasma; then
+            shoot="shoot_wayland_plasma"
+        elif is_wayland; then
+            shoot="shoot_wayland"
+        else
+            shoot="shoot_x"
+        fi
 
         echo "Waiting for selection..." >&2
         $shoot "$filepath"
@@ -98,6 +104,26 @@ shoot_wayland() {
     requires grim
     delay_capture
     grim "${args[@]}" "$1"
+}
+
+shoot_wayland_plasma() {
+    local args
+    if [ "$mode" = "selection" ]; then
+        echo "After selection (and optional edits), press [ENTER] or click on 'Save' or 'Copy'." >&2
+        args=(-brn -o)
+    elif [ "$mode" = "monitor" ]; then
+        args=(-bmn -o)
+    elif [ "$mode" = "window" ]; then
+        args=(-ban -o)
+    elif [ "$mode" = "fullscreen" ]; then
+        args=(-bfn -o)
+    fi
+
+    spectacle "${args[@]}" "$1"
+
+    if [ ! -f "$1" ]; then
+        from_clipboard > "$1"
+    fi
 }
 
 shoot_x() {

--- a/src/_env.bash
+++ b/src/_env.bash
@@ -36,6 +36,10 @@ is_wayland() {
     [ "$NEXTSHOT_ENV" = "wayland" ]
 }
 
+is_plasma() {
+    [ "$DESKTOP_SESSION" = "plasma" ]
+}
+
 is_wayland_detected() {
     [ -n "${WAYLAND_DISPLAY+x}" ]
 }


### PR DESCRIPTION
First of all, thanks for the great tool. Been using it on X11 for a while now and since I am now on Wayland, at least for KDE I could provide a way to use `spectacle` for selection and capture. 

One upside is that spectacle allows for on-the-fly editing within the capture region. Downside is that we rely on pressing either the enter key or the Save or Copy button on the spectacle region capture.

Let me know if that works for you!